### PR TITLE
🐺 Fixed query args separator bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trello-for-wolves",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Node.js wrapper for Trello API...for wolves.",
   "engines": {
     "node": ">=6.11.0"

--- a/src/resources/card.ts
+++ b/src/resources/card.ts
@@ -223,7 +223,7 @@ export default class Card extends BaseResource {
           idMembers?: Array<string>;
           due?: Date | null;
         },
-  ): Promise<any> => this.httpPost('/', queryArgs);
+  ): Promise<any> => this.httpPost('/', { ...queryArgs, separator: '/' });
 
   public associateLabel = (labelId: string): Promise<any> =>
     this.httpPost('/idLabels', { value: labelId });

--- a/src/resources/organization.ts
+++ b/src/resources/organization.ts
@@ -169,7 +169,7 @@ export default class Organization extends BaseResource {
     displayName?: string;
     desc?: string;
     website?: string;
-  }): Promise<any> => this.httpPost('/', queryArgs);
+  }): Promise<any> => this.httpPost('/', { ...queryArgs, separator: '/' });
 
   public uploadLogo = (file: Object): Promise<any> =>
     this.httpPost('/logo', { file });


### PR DESCRIPTION
The `Organization` `addOrganization` function has multiple query args, thus a `separator` must be specified (gleaned from looking at the surrounding code 😅).